### PR TITLE
Change Ctrl-C to Ctrl-[ to make consisten with VIM

### DIFF
--- a/vim-mode.py
+++ b/vim-mode.py
@@ -83,7 +83,7 @@ class VimMode(GObject.Object, Gedit.ViewActivatable):
             self.d_pressed = False
             return True
         # Ctrl-C enters normal mode, only when in insert mode
-        if event.keyval == Gdk.keyval_from_name('c') \
+        if event.keyval == Gdk.keyval_from_name('bracketleft') \
                 and event.state & Gdk.ModifierType.CONTROL_MASK != 0 \
                 and (not self.block or self.is_visual_mode):
             self.normal_mode()


### PR DESCRIPTION
VIM uses Ctrl-[ as alternative to Escape to back to Normal mode, this great plugin should have the same behaviour.